### PR TITLE
disable mouse on pause

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -558,6 +558,7 @@ impl TermLock {
     /// Pause the terminal
     pub fn pause(&mut self) -> Result<()> {
         self.output.take().map(|mut output| {
+            let _ = output.disable_mouse_support();
             // clear drawed contents
             if self.alternate_screen {
                 output.quit_alternate_screen();


### PR DESCRIPTION
This fixes https://github.com/lotabout/skim/issues/235.

I still get annoyed by the issue because my updated shell config hasn't reach everywhere I use skim...