### PR TITLE
fix lotabout/skim#255: parse space key as ' '

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -217,6 +217,8 @@ pub fn from_keyname(keyname: &str) -> Option<Key> {
         "alt-enter" | "alt-ctrl-m"   => Some(AltEnter),
         "alt-tab" | "alt-ctrl-i"     => Some(AltTab),
 
+        "space" => Some(Char(' ')),
+
         ch if ch.chars().count() == 1 => {
             Some(Char(ch.chars().next().expect("input:parse_key: no key is specified")))
         },


### PR DESCRIPTION
Fix https://github.com/lotabout/skim/issues/255