### PR TITLE
Add shutdown timeout

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -48,6 +48,7 @@ use crate::Result;
 const MIN_HEIGHT: usize = 1;
 const WAIT_TIMEOUT: Duration = Duration::from_millis(300);
 const POLLING_TIMEOUT: Duration = Duration::from_millis(10);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(400);
 
 #[derive(Debug, Copy, Clone)]
 pub enum TermHeight {
@@ -263,8 +264,20 @@ impl<UserEvent: Send + 'static> Term<UserEvent> {
 
         termlock.pause(exiting)?;
 
+        let mut no_timeout = {
+            let mut wait_sum = Duration::default();
+            move || {
+                if exiting {
+                    wait_sum += POLLING_TIMEOUT;
+                    wait_sum <= SHUTDOWN_TIMEOUT
+                } else {
+                    true
+                }
+            }
+        };
+
         // wait for the components to stop
-        while self.components_to_stop.load(Ordering::SeqCst) > 0 {
+        while self.components_to_stop.load(Ordering::SeqCst) > 0 && no_timeout() {
             debug!(
                 "pause: components: {}",
                 self.components_to_stop.load(Ordering::SeqCst)


### PR DESCRIPTION
With both xterm (v366) and konsole (20.12.2) using rustc 1.52.1 the
shutdown sometimes hangs indefinitely, so a timeout is added.

--------------

This happens both with and without `clear_on_exit`, and so far I could only reproduce it with release binaries, not with debug ones. Note that this just fixes the symptom, I do not know if the cause is actually misbehavior of the terminal or something else.