### PR TITLE
Disable leading newline

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -75,6 +75,7 @@ pub struct TermOptions {
     raw_mouse: bool,
     hold: bool, // to start term or not on creation
     disable_alternate_screen: bool,
+    has_leading_newline: bool,
 }
 
 impl Default for TermOptions {
@@ -89,6 +90,7 @@ impl Default for TermOptions {
             raw_mouse: false,
             hold: false,
             disable_alternate_screen: false,
+            has_leading_newline: true,
         }
     }
 }
@@ -130,6 +132,10 @@ impl TermOptions {
     }
     pub fn disable_alternate_screen(mut self, disable_alternate_screen: bool) -> Self {
         self.disable_alternate_screen = disable_alternate_screen;
+        self
+    }
+    pub fn has_leading_newline(mut self, has_leading_newline: bool) -> Self {
+        self.has_leading_newline = has_leading_newline;
         self
     }
 }
@@ -582,6 +588,7 @@ struct TermLock {
     clear_on_exit: bool,
     clear_on_start: bool,
     mouse_enabled: bool,
+    has_leading_newline: bool,
     alternate_screen: bool,
     disable_alternate_screen: bool,
     cursor_row: usize,
@@ -598,6 +605,7 @@ impl Default for TermLock {
             max_height: TermHeight::Percent(100),
             min_height: TermHeight::Fixed(3),
             bottom_intact: false,
+            has_leading_newline: true,
             alternate_screen: false,
             disable_alternate_screen: false,
             cursor_row: 0,
@@ -623,6 +631,7 @@ impl TermLock {
         term.screen.clear_on_start(options.clear_on_start);
         term.disable_alternate_screen = options.disable_alternate_screen;
         term.mouse_enabled = options.mouse_enabled;
+        term.has_leading_newline = options.has_leading_newline;
         term
     }
 
@@ -773,8 +782,7 @@ impl TermLock {
         } else {
             // only use part of the screen
 
-            // go to a new line so that existing line won't be messed up
-            if cursor_col > 0 {
+            if self.has_leading_newline && cursor_col > 0 {
                 output.write("\n");
                 cursor_row += 1;
             }


### PR DESCRIPTION
This change adds a new TermOption, "has_leading_newline".

When this option is set to false (default is true), TermLock::ensure_height() would not add a leading newline (=the separator between the original line contents and the new contents) to the output anymore.

When it is set to true, there is no change in ensure_height()'s behavior (the leading newline is present).

I'm using this option and setting it to false in my version of skim (https://github.com/c4eater/skim/tree/disable-leading-newline) because the output looks better without the leading newline.

Here are some screenshots of skim with and without the leading newline:
If has_leading_newline is false:

<img src="https://user-images.githubusercontent.com/2597360/166234538-8b7bb01b-f773-4e9f-b9d4-3fead2c0e275.png" width="320" height="150"/>

If has_leading_newline is true (default):

<img src="https://user-images.githubusercontent.com/2597360/166234422-51fdf340-fc2f-4473-90e2-d86d8125bceb.png" width="320" height="150"/>
