### PR TITLE
add transparency on start

### DIFF
--- a/examples/win.rs
+++ b/examples/win.rs
@@ -16,7 +16,12 @@ impl Draw for Model {
 impl Widget for Model {}
 
 fn main() {
-    let term: Term<()> = Term::with_height(TermHeight::Percent(50)).unwrap();
+    let term: Term<()> = Term::with_options(
+                TermOptions::default()
+                    .height(TermHeight::Percent(50))
+                    .disable_alternate_screen(true)
+                    .clear_on_start(false)
+    ).unwrap();
     let model = Model("Hey, I'm in middle!".to_string());
 
     while let Ok(ev) = term.poll_event() {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -18,9 +18,9 @@ pub struct Screen {
     height: usize,
     cursor: Cursor,
     cells: Vec<Cell>,
-
     painted_cells: Vec<Cell>,
     painted_cursor: Cursor,
+    clear_on_start: bool,
 }
 
 impl Screen {
@@ -33,7 +33,12 @@ impl Screen {
             cursor: Cursor::default(),
             painted_cells: vec![Cell::default(); width * height],
             painted_cursor: Cursor::default(),
+            clear_on_start: false,
         }
+    }
+
+    pub fn clear_on_start(&mut self, clear_on_start: bool) {
+        self.clear_on_start = clear_on_start;
     }
 
     /// get the width of the screen
@@ -173,7 +178,9 @@ impl Screen {
                     col: empty_col_index,
                 });
                 commands.push(Command::ResetAttributes);
-                commands.push(Command::EraseEndOfLine);
+                if self.clear_on_start {
+                    commands.push(Command::EraseEndOfLine);
+                }
                 last_attr = Attr::default();
             }
         }


### PR DESCRIPTION
Create options (disabled by default) to allow "transparency" in tuikit.
more precisely: retain cells which don't need to be changed as they were before tuikit was started.

## example

With win example with the new options:

```rust
                TermOptions::default()
                    .disable_alternate_screen(true)
                    .clear_on_start(false)
```

Running in shell:

```bash
clear
# display an image in term:
blockish /home/yazgoo/Pictures/vimpapers/73lfih7qkrr61.png 
# move cursor to top left:
echo "\e[0;0f"
# run pre-compiled win example:
./target/debug/examples/win
```

Results in:

![image](https://user-images.githubusercontent.com/188526/187537404-43e9ab74-fb7f-4f9b-921a-c2fa44fe2cbb.png)

## new options

- clear on start (default: true): when set to false, will never erase to end of line or erase down
- disable alternate screen (default: false): when set to true, never run rmcup/smcup